### PR TITLE
fix(inference): checks that `required` extends `ReadonlyArray<string>` instead of relying on `keyof` operator

### DIFF
--- a/src/parse-schema/object.ts
+++ b/src/parse-schema/object.ts
@@ -18,10 +18,8 @@ export type ParseObjectSchema<S> = "properties" extends keyof S
     >
   : Object<{}, GetRequired<S>, true, GetOpenProps<S>>;
 
-type GetRequired<S> = "required" extends keyof S
-  ? number extends keyof S["required"]
-    ? S["required"][number]
-    : never
+type GetRequired<S> = S extends { required: ReadonlyArray<string> }
+  ? S["required"][number]
   : never;
 
 type GetOpenProps<S> = "additionalProperties" extends keyof S


### PR DESCRIPTION
Fixes #16