### PR TITLE
Add support for private branded strings

### DIFF
--- a/src/meta-types/exclusion/any.ts
+++ b/src/meta-types/exclusion/any.ts
@@ -12,6 +12,7 @@ export type ExcludeFromAny<Source, Excluded> = {
   const: Source;
   enum: Source;
   primitive: Source;
+  brandedPrimitive: Source;
   array: Source;
   tuple: Source;
   object: Source;

--- a/src/meta-types/exclusion/array.ts
+++ b/src/meta-types/exclusion/array.ts
@@ -18,6 +18,7 @@ export type ExcludeFromArray<Source, Excluded> = {
   const: Source;
   enum: Source;
   primitive: Source;
+  brandedPrimitive: Source;
   array: ExcludeArrs<Source, Excluded>;
   tuple: And<
     DoesExtend<A.Equals<TupleValues<Excluded>, []>, B.True>,

--- a/src/meta-types/exclusion/const.ts
+++ b/src/meta-types/exclusion/const.ts
@@ -16,6 +16,7 @@ export type ExcludeFromConst<Source, Excluded> = {
   const: CheckNotExtendsResolved<Source, Excluded>;
   enum: CheckNotExtendsResolved<Source, Excluded>;
   primitive: CheckNotExtendsResolved<Source, Excluded>;
+  brandedPrimitive: CheckNotExtendsResolved<Source, Excluded>;
   array: CheckNotExtendsResolved<Source, Excluded>;
   tuple: CheckNotExtendsResolved<Source, Excluded>;
   object: ExcludeObject<Source, Excluded>;

--- a/src/meta-types/exclusion/enum.ts
+++ b/src/meta-types/exclusion/enum.ts
@@ -18,6 +18,7 @@ export type ExcludeFromEnum<Source, Excluded> = {
   const: FilterExcluded<Source, Excluded>;
   enum: FilterExcluded<Source, Excluded>;
   primitive: FilterExcluded<Source, Excluded>;
+  brandedPrimitive: FilterExcluded<Source, Excluded>;
   array: FilterExcluded<Source, Excluded>;
   tuple: FilterExcluded<Source, Excluded>;
   object: FilterExcluded<Source, Excluded>;

--- a/src/meta-types/exclusion/index.ts
+++ b/src/meta-types/exclusion/index.ts
@@ -29,6 +29,7 @@ export type Exclude<A, B> = {
   const: ExcludeFromConst<A, B>;
   enum: ExcludeFromEnum<A, B>;
   primitive: ExcludeFromPrimitive<A, B>;
+  brandedPrimitive: ExcludeFromPrimitive<A, B>;
   array: ExcludeFromArray<A, B>;
   tuple: ExcludeFromTuple<A, B>;
   object: ExcludeFromObject<A, B>;

--- a/src/meta-types/exclusion/object.ts
+++ b/src/meta-types/exclusion/object.ts
@@ -28,6 +28,7 @@ export type ExcludeFromObject<S, E> = {
   const: ExcludeConst<S, E>;
   enum: ExcludeEnum<S, E>;
   primitive: S;
+  brandedPrimitive: S;
   array: S;
   tuple: S;
   object: ExcludeObjects<S, E>;

--- a/src/meta-types/exclusion/primitive.ts
+++ b/src/meta-types/exclusion/primitive.ts
@@ -13,6 +13,7 @@ export type ExcludeFromPrimitive<A, B> = {
   const: A;
   enum: A;
   primitive: Value<A> extends Value<B> ? Never : A;
+  brandedPrimitive: Value<A> extends Value<B> ? Never : A;
   array: A;
   tuple: A;
   object: A;

--- a/src/meta-types/exclusion/tuple.ts
+++ b/src/meta-types/exclusion/tuple.ts
@@ -29,6 +29,7 @@ export type ExcludeFromTuple<S, E> = {
   const: ExcludeConst<S, E>;
   enum: ExcludeEnum<S, E>;
   primitive: S;
+  brandedPrimitive: S;
   array: ExcludeArray<S, E>;
   tuple: ExcludeTuples<S, E>;
   object: S;

--- a/src/meta-types/index.ts
+++ b/src/meta-types/index.ts
@@ -4,7 +4,7 @@ import { Any, AnyType, ResolveAny } from "./any";
 import { Never, NeverType, ResolveNever } from "./never";
 import { Const, ConstType, ResolveConst } from "./const";
 import { Enum, EnumType, ResolveEnum } from "./enum";
-import { Primitive, PrimitiveType, ResolvePrimitive } from "./primitive";
+import { Primitive, BrandedPrimitive, PrimitiveType, BrandedPrimitiveType, ResolvePrimitive, ResolveBrandedPrimitive } from "./primitive";
 import { Arr, ArrType, ResolveArr } from "./array";
 import { Tuple, TupleType, ResolveTuple } from "./tuple";
 import { Object, ObjectType, ResolveObject } from "./object";
@@ -23,6 +23,7 @@ export type MetaType =
   | ConstType
   | EnumType
   | PrimitiveType
+  | BrandedPrimitiveType
   | ArrType
   | TupleType
   | ObjectType
@@ -37,6 +38,7 @@ export type Resolve<T, D = Exclude<T, undefined>> = {
   const: ResolveConst<D>;
   enum: ResolveEnum<D>;
   primitive: ResolvePrimitive<D>;
+  brandedPrimitive: ResolveBrandedPrimitive<D>;
   array: ResolveArr<D>;
   tuple: ResolveTuple<D>;
   object: ResolveObject<D>;
@@ -52,6 +54,7 @@ export {
   Const,
   Enum,
   Primitive,
+  BrandedPrimitive,
   Arr,
   Tuple,
   Object,

--- a/src/meta-types/intersection/array.ts
+++ b/src/meta-types/intersection/array.ts
@@ -18,6 +18,7 @@ export type IntersectArr<A, B> = {
   const: IntersectConst<B, A>;
   enum: IntersectEnum<B, A>;
   primitive: Never;
+  brandedPrimitive: Never;
   array: IntersectArrs<A, B>;
   tuple: IntersectTuple<B, A>;
   object: Never;

--- a/src/meta-types/intersection/const.ts
+++ b/src/meta-types/intersection/const.ts
@@ -14,6 +14,7 @@ export type IntersectConst<A, B> = {
   const: CheckExtendsResolved<A, B>;
   enum: CheckExtendsResolved<A, B>;
   primitive: CheckExtendsResolved<A, B>;
+  brandedPrimitive: CheckExtendsResolved<A, B>;
   array: CheckExtendsResolved<A, B>;
   tuple: CheckExtendsResolved<A, B>;
   object: ToObject<A, B>;

--- a/src/meta-types/intersection/enum.ts
+++ b/src/meta-types/intersection/enum.ts
@@ -14,6 +14,7 @@ export type IntersectEnum<A, B> = {
   const: IntersectConst<B, A>;
   enum: FilterUnintersecting<A, B>;
   primitive: FilterUnintersecting<A, B>;
+  brandedPrimitive: FilterUnintersecting<A, B>;
   array: FilterUnintersecting<A, B>;
   tuple: FilterUnintersecting<A, B>;
   object: FilterUnintersecting<A, B>;

--- a/src/meta-types/intersection/exclusion.ts
+++ b/src/meta-types/intersection/exclusion.ts
@@ -17,6 +17,7 @@ export type IntersectExclusion<A, B> = {
   const: Exclusion<Intersect<Value<A>, B>, Excluded<A>>;
   enum: Exclusion<Intersect<Value<A>, B>, Excluded<A>>;
   primitive: Exclusion<Intersect<Value<A>, B>, Excluded<A>>;
+  brandedPrimitive: Exclusion<Intersect<Value<A>, B>, Excluded<A>>;
   array: Exclusion<Intersect<Value<A>, B>, Excluded<A>>;
   tuple: Exclusion<Intersect<Value<A>, B>, Excluded<A>>;
   object: Exclusion<Intersect<Value<A>, B>, Excluded<A>>;

--- a/src/meta-types/intersection/index.ts
+++ b/src/meta-types/intersection/index.ts
@@ -35,6 +35,7 @@ export type ClearIntersections<T> = {
   const: T;
   enum: T;
   primitive: T;
+  brandedPrimitive: T;
   array: ClearArrIntersections<T>;
   tuple: ClearTupleIntersections<T>;
   object: ClearObjectIntersections<T>;
@@ -54,6 +55,7 @@ export type Intersect<A, B> = {
   const: IntersectConst<A, B>;
   enum: IntersectEnum<A, B>;
   primitive: IntersectPrimitive<A, B>;
+  brandedPrimitive: IntersectPrimitive<A, B>;
   array: IntersectArr<A, B>;
   tuple: IntersectTuple<A, B>;
   object: IntersectObject<A, B>;

--- a/src/meta-types/intersection/object.ts
+++ b/src/meta-types/intersection/object.ts
@@ -35,6 +35,7 @@ export type IntersectObject<A, B> = {
   const: IntersectConst<B, A>;
   enum: IntersectEnum<B, A>;
   primitive: Never;
+  brandedPrimitive: Never;
   array: Never;
   tuple: Never;
   object: IntersectObjects<A, B>;

--- a/src/meta-types/intersection/primitive.ts
+++ b/src/meta-types/intersection/primitive.ts
@@ -18,6 +18,11 @@ export type IntersectPrimitive<A, B> = {
     : Value<B> extends Value<A>
     ? B
     : Never;
+  brandedPrimitive: Value<A> extends Value<B>
+    ? A
+    : Value<B> extends Value<A>
+    ? B
+    : Never;
   array: Never;
   tuple: Never;
   object: Never;

--- a/src/meta-types/intersection/tuple.ts
+++ b/src/meta-types/intersection/tuple.ts
@@ -34,6 +34,7 @@ export type IntersectTuple<A, B> = {
   const: IntersectConst<B, A>;
   enum: IntersectEnum<B, A>;
   primitive: Never;
+  brandedPrimitive: Never;
   array: IntersectTupleToArray<A, B>;
   tuple: IntersectTuples<A, B>;
   object: Never;

--- a/src/meta-types/intersection/union.ts
+++ b/src/meta-types/intersection/union.ts
@@ -19,6 +19,7 @@ export type IntersectUnion<A, B> = {
   const: DistributeIntersection<A, B>;
   enum: DistributeIntersection<A, B>;
   primitive: DistributeIntersection<A, B>;
+  brandedPrimitive: DistributeIntersection<A, B>;
   array: DistributeIntersection<A, B>;
   tuple: DistributeIntersection<A, B>;
   object: DistributeIntersection<A, B>;

--- a/src/meta-types/primitive.ts
+++ b/src/meta-types/primitive.ts
@@ -1,12 +1,26 @@
 import { Get } from "../utils";
 
 export type PrimitiveType = "primitive";
+export type BrandedPrimitiveType = "brandedPrimitive";
 
 export type Primitive<L> = {
   type: PrimitiveType;
   value: L;
 };
 
+export declare const BrandName: unique symbol;
+
+export interface Branded<B> {
+  [BrandName]: B;
+}
+
+export type BrandedPrimitive<L,B> = {
+  type: BrandedPrimitiveType;
+  value: L;
+  brand: B;
+}
+
 export type Value<L> = Get<L, "value">;
 
 export type ResolvePrimitive<T> = Get<T, "value">;
+export type ResolveBrandedPrimitive<T> = Get<T, "value"> & Branded<Get<T, "brand">>;

--- a/src/meta-types/utils.ts
+++ b/src/meta-types/utils.ts
@@ -14,6 +14,7 @@ export type IsRepresentable<A> = {
   const: true;
   enum: IsEnumRepresentable<A>;
   primitive: true;
+  brandedPrimitive: true;
   array: true; // Empty array will represent any array
   tuple: IsTupleRepresentable<A>;
   object: IsObjectRepresentable<A>;

--- a/src/parse-schema/index.ts
+++ b/src/parse-schema/index.ts
@@ -1,4 +1,4 @@
-import { Primitive, Any, Never } from "../meta-types";
+import { Primitive, BrandedPrimitive, Any, Never } from "../meta-types";
 
 import { ParseConstSchema } from "./const";
 import { ParseEnumSchema } from "./enum";
@@ -11,6 +11,8 @@ import { ParseAllOfSchema } from "./allOf";
 import { ParseNotSchema } from "./not";
 import { ParseIfThenElseSchema } from "./ifThenElse";
 
+import { Get } from '../utils/get'
+
 export type ParseSchema<S> = {
   any: Any;
   never: Never;
@@ -18,6 +20,7 @@ export type ParseSchema<S> = {
   boolean: Primitive<boolean>;
   number: Primitive<number>;
   string: Primitive<string>;
+  brandedString: BrandedPrimitive<string,Get<S,"x-brand">>
   mixed: ParseMixedSchema<S>;
   object: ParseObjectSchema<S>;
   array: ParseArrSchema<S>;
@@ -58,7 +61,7 @@ type InferSchemaType<S> = S extends true | string
     : S["type"] extends "integer" | "number"
     ? "number"
     : S["type"] extends "string"
-    ? "string"
+    ? ( "x-brand" extends keyof S ? 'brandedString' : "string")
     : S["type"] extends "object"
     ? "object"
     : S["type"] extends "array"

--- a/tests/e2e/branded-string.test.ts
+++ b/tests/e2e/branded-string.test.ts
@@ -1,0 +1,96 @@
+import Ajv from "ajv";
+
+import { FromSchema, JSONSchema } from "index";
+
+var ajv = new Ajv();
+
+const guard = <S extends JSONSchema>(schema:S) => {
+  return ajv.compile(schema) as (t: unknown) => t is FromSchema<S>
+}
+const check = <S extends JSONSchema>(schema:S) => {
+  const validator = guard(schema)
+  return (value: unknown) => {
+    if (validator(value)) {
+      return value
+    } else {
+      const text = ajv.errorsText()
+      throw new Error(text)
+    }
+  }
+}
+
+describe("Branded String schemas", () => {
+  const stringSchema = { type: "string", 'x-brand': 'MyString' } as const;
+  type String = FromSchema<typeof stringSchema>;
+  const stringChecker = check(stringSchema)
+
+  const anotherStringSchema = { type: "string", 'x-brand': 'AnotherString' } as const;
+  type AnotherString = FromSchema<typeof anotherStringSchema>;
+  const anotherStringChecker = check(anotherStringSchema)
+
+  it("rejects string value at compile time", () => {
+    // @ts-expect-error
+    const stringInstance : String = "apples";
+    expect(ajv.validate(stringSchema, stringInstance)).toBe(true);
+  });
+
+  it("rejects other values at compile time (number)", () => {
+    // @ts-expect-error
+    const stringInstance : String = 42;
+    expect(ajv.validate(stringSchema, stringInstance)).toBe(false);
+  });
+
+  it("rejects other values at compile time (object)", () => {
+    // @ts-expect-error
+    const stringInstance : String = {};
+    expect(ajv.validate(stringSchema, stringInstance)).toBe(false);
+  });
+
+  it("accepts a checked value (string)", () => {
+    const stringInstance : String = stringChecker("apples");
+    expect(ajv.validate(stringSchema, stringInstance)).toBe(true);
+  });
+
+  it("accepts a checked value (branded string)", () => {
+    const stringInstance : String = stringChecker("apples");
+    const anotherStringInstance : AnotherString = anotherStringChecker(stringInstance)
+    expect(ajv.validate(anotherStringSchema, anotherStringInstance)).toBe(true);
+  });
+
+  it("rejects other checked values at runtime (number)", () => {
+    expect( () => {
+      // will throw
+      const stringInstance : String = stringChecker(42);
+      return stringInstance;
+    }).toThrow();
+  });
+
+  it("rejects other checked values at runtime (object)", () => {
+    expect( () => {
+      // will throw
+      const stringInstance : String = stringChecker({});
+      return stringInstance;
+    }).toThrow();
+  });
+
+  it("rejects cross-branding values", () => {
+    const stringInstance : String = stringChecker("apples");
+    // @ts-expect-error
+    const anotherStringInstance : AnotherString = stringInstance
+    expect(ajv.validate(anotherStringSchema, anotherStringInstance)).toBe(true);
+  });
+
+  const deepSchema = { type: "object", required: [ 'thisString'], properties: { thisString: stringSchema }  }as const;
+  type Deep = FromSchema<typeof deepSchema>;
+  const deepChecker = check(deepSchema)
+
+  it("accepts deep type", () => {
+    const deepInstance : Deep = deepChecker({ thisString: "apples" });
+    const stringInstance : String = deepInstance.thisString;
+    // @ts-expect-error
+    const anotherStringInstance : AnotherString = deepInstance.thisString;
+    expect(ajv.validate(stringSchema, stringInstance)).toBe(true);
+    expect(ajv.validate(anotherStringSchema, anotherStringInstance)).toBe(true);
+  })
+
+});


### PR DESCRIPTION
We add support for branded types using a private `x-brand` extension.

The implementation is currently applied to the `string` type.