### PR TITLE
chore: exclude dev config files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "json-schema-to-ts",
   "version": "2.7.0-beta.0",
   "description": "Infer typescript types from your JSON schemas!",
+  "files": [
+    "lib"
+  ],
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "types": "lib/types/index.d.ts",


### PR DESCRIPTION
Hello,

I recently noticed that the published version of the library included dev configuration files:
- `.dependency-cruiser.js`
- `.eslintignore`
- `.eslintrc.js`
- `.nvmrc`
- `.prettierignore`
- `.prettierrc`

This PR restricts the list of published files to `lib` only (plus standard files such as `LICENSE`, `package.json` and `README.md`).

WDYT?