### PR TITLE
feat: support $defs attribute

### DIFF
--- a/src/definitions/extendedJsonSchema.ts
+++ b/src/definitions/extendedJsonSchema.ts
@@ -33,6 +33,10 @@ export type ExtendedJSONSchema<
        */
       $schema?: string | undefined;
       $comment?: string | undefined;
+      /**
+       * @see https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2.4
+       */
+      $defs?: Readonly<Record<string, ExtendedJSONSchema<EXTENSION>>>;
 
       /**
        * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.1
@@ -113,6 +117,7 @@ export type ExtendedJSONSchema<
 
       /**
        * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9
+       * @deprecated Use $defs instead (https://json-schema.org/draft/2020-12/json-schema-core#appendix-G-2.6.1.2)
        */
       definitions?: Readonly<Record<string, ExtendedJSONSchema<EXTENSION>>>;
 

--- a/src/definitions/jsonSchema.ts
+++ b/src/definitions/jsonSchema.ts
@@ -39,6 +39,10 @@ export type JSONSchema =
        */
       $schema?: string | undefined;
       $comment?: string | undefined;
+      /**
+       * @see https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2.4
+       */
+      $defs?: Readonly<Record<string, JSONSchema>>;
 
       /**
        * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.1
@@ -114,6 +118,7 @@ export type JSONSchema =
 
       /**
        * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9
+       * @deprecated Use $defs instead (https://json-schema.org/draft/2020-12/json-schema-core#appendix-G-2.6.1.2)
        */
       definitions?: Readonly<Record<string, JSONSchema>>;
 

--- a/src/parse-schema/references/internal.unit.test.ts
+++ b/src/parse-schema/references/internal.unit.test.ts
@@ -2,6 +2,7 @@ import type { FromSchema } from "~/index";
 
 import { ajv } from "../ajv.util.test";
 
+// remove this when `defintions` keyword is removed from JSON Schema
 describe("Definitions", () => {
   describe("Default case", () => {
     const personSchema = {
@@ -139,6 +140,170 @@ describe("Definitions", () => {
           properties: {
             firstName: { $ref: "#/definitions/name" },
             lastName: { $ref: "#/definitions/name" },
+          },
+          additionalProperties: false,
+        },
+      },
+    } as const;
+
+    type Judy = FromSchema<typeof judySchema>;
+    let judyInstance: Judy;
+
+    it("accepts a valid person", () => {
+      judyInstance = { judy: { firstName: "judy", lastName: "foster" } };
+      expect(ajv.validate(judySchema, judyInstance)).toBe(true);
+    });
+
+    it("rejects an invalid person", () => {
+      judyInstance = {
+        judy: {
+          firstName: "judy",
+          // @ts-expect-error
+          lastName: true,
+        },
+      };
+      expect(ajv.validate(judySchema, judyInstance)).toBe(false);
+    });
+  });
+});
+
+describe("$defs", () => {
+  describe("Default case", () => {
+    const personSchema = {
+      type: "object",
+      properties: {
+        firstName: { $ref: "#/$defs/name" },
+        lastName: { $ref: "#/$defs/name" },
+      },
+      required: ["firstName", "lastName"],
+      additionalProperties: false,
+      $defs: {
+        name: {
+          type: "string",
+        },
+      },
+    } as const;
+
+    type Person = FromSchema<typeof personSchema>;
+    let personInstance: Person;
+
+    it("accepts a valid person", () => {
+      personInstance = { firstName: "judy", lastName: "foster" };
+      expect(ajv.validate(personSchema, personInstance)).toBe(true);
+    });
+
+    it("rejects an invalid person", () => {
+      // @ts-expect-error
+      personInstance = { firstName: 42, lastName: true };
+      expect(ajv.validate(personSchema, personInstance)).toBe(false);
+    });
+  });
+
+  describe("Nested path", () => {
+    const personSchema = {
+      type: "object",
+      properties: {
+        firstName: { $ref: "#/$defs/user/properties/name" },
+        lastName: { $ref: "#/$defs/user/properties/name" },
+      },
+      required: ["firstName", "lastName"],
+      additionalProperties: false,
+      $defs: {
+        user: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+          },
+        },
+      },
+    } as const;
+
+    type Person = FromSchema<typeof personSchema>;
+
+    let personInstance: Person;
+
+    it("accepts a valid person", () => {
+      personInstance = { firstName: "judy", lastName: "foster" };
+      expect(ajv.validate(personSchema, personInstance)).toBe(true);
+    });
+
+    it("rejects an invalid person", () => {
+      // @ts-expect-error
+      personInstance = { firstName: 42, lastName: true };
+      expect(ajv.validate(personSchema, personInstance)).toBe(false);
+    });
+  });
+
+  describe("In combinaison with keywords", () => {
+    const judySchema = {
+      type: "object",
+      properties: {
+        judy: {
+          $ref: "#/$defs/person",
+          required: ["lastName"],
+          additionalProperties: true,
+        },
+      },
+      required: ["judy"],
+      additionalProperties: false,
+      $defs: {
+        person: {
+          type: "object",
+          properties: {
+            firstName: { type: "string" },
+            lastName: { type: "string" },
+          },
+          required: ["firstName"],
+          additionalProperties: false,
+        },
+      },
+    } as const;
+
+    type Judy = FromSchema<typeof judySchema>;
+    let judyInstance: Judy;
+
+    it("rejects additional properties (both additionalProperties apply)", () => {
+      judyInstance = {
+        judy: {
+          firstName: "judy",
+          lastName: "foster",
+          // @ts-expect-error
+          additionalProp: true,
+        },
+      };
+      expect(ajv.validate(judySchema, judyInstance)).toBe(false);
+    });
+
+    it("rejects if firstName OR last name misses (both required apply)", () => {
+      judyInstance = {
+        // @ts-expect-error
+        judy: { firstName: "judy" },
+      };
+      expect(ajv.validate(judySchema, judyInstance)).toBe(false);
+
+      judyInstance = {
+        // @ts-expect-error
+        judy: { lastName: "foster" },
+      };
+      expect(ajv.validate(judySchema, judyInstance)).toBe(false);
+    });
+  });
+
+  describe("$defs using other $defs", () => {
+    const judySchema = {
+      type: "object",
+      properties: {
+        judy: { $ref: "#/$defs/person" },
+      },
+      required: ["judy"],
+      additionalProperties: false,
+      $defs: {
+        name: { type: "string" },
+        person: {
+          type: "object",
+          properties: {
+            firstName: { $ref: "#/$defs/name" },
+            lastName: { $ref: "#/$defs/name" },
           },
           additionalProperties: false,
         },

--- a/src/tests/readme/defs.test.ts
+++ b/src/tests/readme/defs.test.ts
@@ -1,0 +1,28 @@
+import type { A } from "ts-toolbelt";
+
+import type { FromSchema } from "~/index";
+
+const userSchema = {
+  type: "object",
+  properties: {
+    name: { $ref: "#/$defs/name" },
+    age: { $ref: "#/$defs/age" },
+  },
+  required: ["name", "age"],
+  additionalProperties: false,
+  $defs: {
+    name: { type: "string" },
+    age: { type: "integer" },
+  },
+} as const;
+
+type ReceivedUser = FromSchema<typeof userSchema>;
+type ExpectedUser = {
+  name: string;
+  age: number;
+};
+
+type AssertUser = A.Equals<ReceivedUser, ExpectedUser>;
+const assertUser: AssertUser = 1;
+assertUser;
+


### PR DESCRIPTION
This PR adds the official `$defs` attribute (https://json-schema.org/understanding-json-schema/structuring#defs). Currently there is only the `definitions` attribute, which was part of the JSON Schema RFC of Henry Andrews (https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9) but this has never been applied to the real JSON Schema RFC, because Henry changed the name of definitions to $defs in v02 of his RFC branch (https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-02#appendix-A and https://json-schema.org/draft/2020-12/json-schema-core#appendix-G-2.6.1.2).

This said: `defintions` is no valid JSON Schema attribute. It should be removed. I think it's save to remove it, because it never has been an official / valid attribute. For now I did not removed it but I would recommend removing it and releasing this package with a new major version.

It would be great if @ThomasAribart could merge and release these changes as soon as possible because the current implementation is not matching the JSON Schema standard.